### PR TITLE
Add minimal JUMBF support

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ handler = StreamingHandler(
     signer_id=signer_id_example,
     timestamp=stream_timestamp,
     custom_metadata=stream_custom_payload,
-    # metadata_format defaults to "basic"
+    # metadata_format defaults to "basic" (also accepts "manifest", "cbor_manifest", or "jumbf")
     # encode_first_chunk_only defaults to True, which is common for streaming
 )
 
@@ -352,7 +352,7 @@ encoded_text_manifest = UnicodeMetadata.embed_metadata(
     private_key=private_key,
     signer_id=signer_id_manifest,
     timestamp=int(time.time()),
-    metadata_format="cbor_manifest",  # Use the CBOR manifest format
+    metadata_format="cbor_manifest",  # Use the CBOR manifest format ("jumbf" is also supported)
     claim_generator="EncypherAI README Example v2.3",
     actions=[
         {

--- a/docs/package/changelog.md
+++ b/docs/package/changelog.md
@@ -2,6 +2,13 @@
 
 This document provides a chronological list of notable changes for each version of EncypherAI.
 
+## 2.4.2 (07-08-2025)
+
+### Added
+- **JUMBF Embedding:** Added support for a `jumbf` metadata format which stores
+  the inner payload in a compact binary JUMBF box. The decoder now automatically
+  detects JSON, CBOR, or JUMBF embeddings.
+
 ## 2.4.0 (06-28-2025)
 
 ### Added

--- a/docs/package/changelog.md
+++ b/docs/package/changelog.md
@@ -2,7 +2,7 @@
 
 This document provides a chronological list of notable changes for each version of EncypherAI.
 
-## 2.4.2 (07-08-2025)
+## 2.5.0 (07-07-2025)
 
 ### Added
 - **JUMBF Embedding:** Added support for a `jumbf` metadata format which stores

--- a/docs/package/technical/content-hash-and-embedding.md
+++ b/docs/package/technical/content-hash-and-embedding.md
@@ -60,6 +60,8 @@ Our implementation embeds the entire manifest directly in the content. The conte
 ### Embedding Process
 
 ```python
+from encypher.core.payloads import serialize_jumbf_payload, deserialize_jumbf_payload
+
 def embed_metadata(text, metadata, metadata_format="json"):
     """
     Embeds metadata into text using Unicode variation selectors.
@@ -67,7 +69,8 @@ def embed_metadata(text, metadata, metadata_format="json"):
     Args:
         text (str): The text to embed metadata into
         metadata (dict or bytes): The metadata to embed
-        metadata_format (str): Format of the metadata ("json" or "cbor_manifest")
+        metadata_format (str): Format of the metadata
+            ("json", "cbor_manifest", or "jumbf")
 
     Returns:
         str: Text with embedded metadata
@@ -80,6 +83,8 @@ def embed_metadata(text, metadata, metadata_format="json"):
             serialized = cbor2.dumps(metadata)
         else:
             serialized = metadata  # Already serialized
+    elif metadata_format == "jumbf":
+        serialized = serialize_jumbf_payload(metadata)
     else:
         raise ValueError(f"Unsupported metadata format: {metadata_format}")
 
@@ -103,7 +108,7 @@ def extract_metadata(text, metadata_format="json"):
 
     Args:
         text (str): Text with embedded metadata
-        metadata_format (str): Format of the metadata ("json" or "cbor_manifest")
+        metadata_format (str): Format of the metadata ("json", "cbor_manifest", or "jumbf")
 
     Returns:
         dict or bytes: Extracted metadata
@@ -126,6 +131,8 @@ def extract_metadata(text, metadata_format="json"):
         return json.loads(serialized.decode("utf-8"))
     elif metadata_format == "cbor_manifest":
         return cbor2.loads(serialized)
+    elif metadata_format == "jumbf":
+        return deserialize_jumbf_payload(serialized)
     else:
         raise ValueError(f"Unsupported metadata format: {metadata_format}")
 ```

--- a/encypher/__init__.py
+++ b/encypher/__init__.py
@@ -6,7 +6,7 @@ variation selectors.
 This package provides tools for invisible metadata encoding in AI-generated text.
 """
 
-__version__ = "2.3.0"
+__version__ = "2.4.2"
 
 from encypher.config.settings import Settings
 from encypher.core.unicode_metadata import MetadataTarget, UnicodeMetadata

--- a/encypher/core/payloads.py
+++ b/encypher/core/payloads.py
@@ -184,9 +184,7 @@ def serialize_jumbf_payload(payload: Dict[str, Any]) -> bytes:
         json_bytes = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
         box_length = 8 + len(json_bytes)
         jumbf_bytes = struct.pack(">I4s", box_length, b"jumb") + json_bytes
-        logger.debug(
-            f"Successfully serialized payload to JUMBF bytes, length: {len(jumbf_bytes)} bytes."
-        )
+        logger.debug(f"Successfully serialized payload to JUMBF bytes, length: {len(jumbf_bytes)} bytes.")
         return jumbf_bytes
     except Exception as e:
         logger.error(f"Unexpected error during JUMBF serialization: {e}", exc_info=True)

--- a/encypher/core/payloads.py
+++ b/encypher/core/payloads.py
@@ -1,4 +1,5 @@
 import json
+import struct
 from typing import Any, Dict, List, Literal, Optional, TypedDict, Union, cast
 
 import cbor2
@@ -99,7 +100,7 @@ class OuterPayload(TypedDict):
     """
 
     # The format literal is extended to include new formats.
-    format: Literal["basic", "manifest", "cbor_manifest", "c2pa_v2_2"]
+    format: Literal["basic", "manifest", "cbor_manifest", "c2pa_v2_2", "jumbf"]
     signer_id: str
     # The payload can be a dictionary for JSON-based formats, or a
     # base64-encoded string for binary formats like CBOR.
@@ -167,3 +168,51 @@ def deserialize_c2pa_payload_from_cbor(cbor_bytes: bytes) -> C2PAPayload:
     except Exception as e:
         logger.error(f"Unexpected error during C2PA CBOR deserialization: {e}", exc_info=True)
         raise RuntimeError(f"Unexpected error deserializing C2PA payload from CBOR: {e}")
+
+
+def serialize_jumbf_payload(payload: Dict[str, Any]) -> bytes:
+    """Serializes a payload dictionary into a minimal JUMBF box.
+
+    The function creates a single JUMBF box with a 4 byte length field and a
+    4 byte box type (``b"jumb"``). The payload is encoded as canonical JSON and
+    stored as the box contents. This is **not** a full implementation of
+    ISO/IEC 19566‑5 but provides a deterministic binary representation suitable
+    for signing and unit tests.
+    """
+    logger.debug("Attempting to serialize payload to JUMBF bytes.")
+    try:
+        json_bytes = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        box_length = 8 + len(json_bytes)
+        jumbf_bytes = struct.pack(">I4s", box_length, b"jumb") + json_bytes
+        logger.debug(
+            f"Successfully serialized payload to JUMBF bytes, length: {len(jumbf_bytes)} bytes."
+        )
+        return jumbf_bytes
+    except Exception as e:
+        logger.error(f"Unexpected error during JUMBF serialization: {e}", exc_info=True)
+        raise RuntimeError(f"Unexpected error serializing payload to JUMBF: {e}")
+
+
+def deserialize_jumbf_payload(jumbf_bytes: bytes) -> Dict[str, Any]:
+    """Deserializes bytes produced by :func:`serialize_jumbf_payload`."""
+    logger.debug(f"Attempting to deserialize {len(jumbf_bytes)} bytes from JUMBF.")
+    try:
+        if len(jumbf_bytes) < 8:
+            raise ValueError("JUMBF data too short.")
+        length, box_type = struct.unpack(">I4s", jumbf_bytes[:8])
+        if box_type != b"jumb":
+            raise ValueError(f"Unexpected JUMBF box type: {box_type!r}")
+        if length != len(jumbf_bytes):
+            raise ValueError("JUMBF length mismatch.")
+        json_bytes = jumbf_bytes[8:]
+        payload = json.loads(json_bytes.decode("utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("Deserialized JUMBF data is not a dictionary.")
+        logger.debug("Successfully deserialized JUMBF bytes to payload dictionary.")
+        return payload
+    except json.JSONDecodeError as e:
+        logger.error(f"JUMBF JSON decoding failed: {e}", exc_info=True)
+        raise ValueError(f"Failed to decode JUMBF bytes: {e}")
+    except Exception as e:
+        logger.error(f"Unexpected error during JUMBF deserialization: {e}", exc_info=True)
+        raise RuntimeError(f"Unexpected error deserializing JUMBF payload: {e}")

--- a/encypher/core/unicode_metadata.py
+++ b/encypher/core/unicode_metadata.py
@@ -36,9 +36,9 @@ from .payloads import (
     ManifestPayload,
     OuterPayload,
     deserialize_c2pa_payload_from_cbor,
+    deserialize_jumbf_payload,
     serialize_c2pa_payload_to_cbor,
     serialize_jumbf_payload,
-    deserialize_jumbf_payload,
     serialize_payload,
 )
 from .signing import extract_payload_from_cose_sign1, sign_c2pa_cose, sign_payload, verify_c2pa_cose, verify_signature
@@ -451,9 +451,7 @@ class UnicodeMetadata:
 
         if metadata_format not in ("basic", "manifest", "cbor_manifest", "c2pa_v2_2", "jumbf"):
             logger.error("metadata_format must be 'basic', 'manifest', 'cbor_manifest', 'jumbf', or 'c2pa_v2_2'.")
-            raise ValueError(
-                "metadata_format must be 'basic', 'manifest', 'cbor_manifest', 'jumbf', or 'c2pa_v2_2'."
-            )
+            raise ValueError("metadata_format must be 'basic', 'manifest', 'cbor_manifest', 'jumbf', or 'c2pa_v2_2'.")
 
         if model_id is not None and not isinstance(model_id, str):
             logger.error("If provided, 'model_id' must be a string.")
@@ -607,9 +605,7 @@ class UnicodeMetadata:
                 signature_b64 = base64.urlsafe_b64encode(signature).rstrip(b"=").decode("ascii")
                 payload_for_outer_dict = base64.b64encode(jumbf_bytes).decode("utf-8")
                 actual_payload_type_for_outer = "jumbf"
-                logger.debug(
-                    f"JUMBF payload signed successfully. Signature (base64): {signature_b64[:10]}..."
-                )
+                logger.debug(f"JUMBF payload signed successfully. Signature (base64): {signature_b64[:10]}...")
             except Exception as e:
                 logger.exception("Failed to process or sign JUMBF payload.")
                 raise RuntimeError(f"Failed to process or sign JUMBF payload: {e}") from e

--- a/encypher/core/unicode_metadata.py
+++ b/encypher/core/unicode_metadata.py
@@ -37,6 +37,8 @@ from .payloads import (
     OuterPayload,
     deserialize_c2pa_payload_from_cbor,
     serialize_c2pa_payload_to_cbor,
+    serialize_jumbf_payload,
+    deserialize_jumbf_payload,
     serialize_payload,
 )
 from .signing import extract_payload_from_cose_sign1, sign_c2pa_cose, sign_payload, verify_c2pa_cose, verify_signature
@@ -447,9 +449,11 @@ class UnicodeMetadata:
             logger.error("'target' must be a string or MetadataTarget enum member.")
             raise TypeError("'target' must be a string or MetadataTarget enum member.")
 
-        if metadata_format not in ("basic", "manifest", "cbor_manifest", "c2pa_v2_2"):
-            logger.error("metadata_format must be 'basic', 'manifest', 'cbor_manifest', or 'c2pa_v2_2'.")
-            raise ValueError("metadata_format must be 'basic', 'manifest', 'cbor_manifest', or 'c2pa_v2_2'.")
+        if metadata_format not in ("basic", "manifest", "cbor_manifest", "c2pa_v2_2", "jumbf"):
+            logger.error("metadata_format must be 'basic', 'manifest', 'cbor_manifest', 'jumbf', or 'c2pa_v2_2'.")
+            raise ValueError(
+                "metadata_format must be 'basic', 'manifest', 'cbor_manifest', 'jumbf', or 'c2pa_v2_2'."
+            )
 
         if model_id is not None and not isinstance(model_id, str):
             logger.error("If provided, 'model_id' must be a string.")
@@ -542,6 +546,29 @@ class UnicodeMetadata:
                 cbor_manifest_dict["ai_info"]["model_id"] = model_id
             payload_data["manifest"] = cbor_manifest_dict
             # The actual CBOR processing will happen during signing/packaging
+        elif metadata_format == "jumbf":
+            logger.debug("Using 'jumbf' metadata format.")
+            iso_timestamp = cls._format_timestamp(timestamp)
+            payload_data = {
+                "signer_id": signer_id,
+                "timestamp": iso_timestamp,
+                "format": "manifest",
+            }
+            jumbf_manifest_dict: Dict[str, Any] = {}
+            if claim_generator:
+                jumbf_manifest_dict["claim_generator"] = claim_generator
+            if actions:
+                jumbf_manifest_dict["actions"] = actions
+            if ai_info:
+                jumbf_manifest_dict["ai_info"] = ai_info
+            if custom_claims:
+                jumbf_manifest_dict["custom_claims"] = custom_claims
+            if model_id:
+                if "ai_info" not in jumbf_manifest_dict:
+                    jumbf_manifest_dict["ai_info"] = {}
+                jumbf_manifest_dict["ai_info"]["model_id"] = model_id
+            payload_data["manifest"] = jumbf_manifest_dict
+            # JUMBF binary processing will happen during signing/packaging
         else:
             logger.error(f"Unsupported metadata_format: {metadata_format}")
             raise ValueError(f"Unsupported metadata_format: {metadata_format}")
@@ -573,6 +600,19 @@ class UnicodeMetadata:
             except Exception as e:
                 logger.exception("Failed to process or sign CBOR manifest payload.")
                 raise RuntimeError(f"Failed to process or sign CBOR manifest payload: {e}") from e
+        elif metadata_format == "jumbf":
+            try:
+                jumbf_bytes = serialize_jumbf_payload(payload_data)
+                signature = sign_payload(private_key, jumbf_bytes)
+                signature_b64 = base64.urlsafe_b64encode(signature).rstrip(b"=").decode("ascii")
+                payload_for_outer_dict = base64.b64encode(jumbf_bytes).decode("utf-8")
+                actual_payload_type_for_outer = "jumbf"
+                logger.debug(
+                    f"JUMBF payload signed successfully. Signature (base64): {signature_b64[:10]}..."
+                )
+            except Exception as e:
+                logger.exception("Failed to process or sign JUMBF payload.")
+                raise RuntimeError(f"Failed to process or sign JUMBF payload: {e}") from e
         else:  # For "basic" or "manifest" (JSON-based)
             try:
                 # Serialize the *complete* payload (basic or manifest dict) to canonical JSON bytes
@@ -969,6 +1009,16 @@ class UnicodeMetadata:
                     actual_inner_payload = cbor_data
             except (binascii.Error, cbor2.CBORDecodeError) as e:
                 logger.error(f"Failed to decode CBOR manifest payload: {e}")
+                return False, signer_id, None
+        elif payload_format == "jumbf":
+            if not isinstance(inner_payload, str):
+                logger.error(f"JUMBF payload expected string, got {type(inner_payload)}.")
+                return False, signer_id, None
+            try:
+                payload_to_verify_bytes = base64.b64decode(inner_payload.encode("utf-8"))
+                actual_inner_payload = deserialize_jumbf_payload(payload_to_verify_bytes)
+            except (binascii.Error, ValueError) as e:
+                logger.error(f"Failed to decode JUMBF payload: {e}")
                 return False, signer_id, None
         elif payload_format in ("basic", "manifest"):
             if not isinstance(inner_payload, dict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "encypher-ai"
-version = "2.4.1"
+version = "2.4.2"
 description = "Embed invisible metadata in AI-generated text using zero-width characters."
 readme = "README.md"
 authors = [{name = "EncypherAI Team"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "encypher-ai"
-version = "2.4.2"
+version = "2.5.0"
 description = "Embed invisible metadata in AI-generated text using zero-width characters."
 readme = "README.md"
 authors = [{name = "EncypherAI Team"}]

--- a/tests/core/test_unicode_metadata.py
+++ b/tests/core/test_unicode_metadata.py
@@ -132,7 +132,11 @@ class TestUnicodeMetadata:
 
     @pytest.mark.parametrize(
         "metadata_format, metadata_fixture",
-        [("basic", "basic_metadata"), ("manifest", "manifest_metadata")],
+        [
+            ("basic", "basic_metadata"),
+            ("manifest", "manifest_metadata"),
+            ("jumbf", "manifest_metadata"),
+        ],
     )
     def test_embed_verify_extract_success(
         self,
@@ -196,14 +200,18 @@ class TestUnicodeMetadata:
         # Note: Timestamp formatting might differ slightly if not ISO string initially
         # We compare the core content
         assert extracted_payload is not None
-        assert extracted_payload.get("format") == metadata_format
+        if metadata_format == "jumbf":
+            # JUMBF inner payload uses manifest structure
+            assert extracted_payload.get("format") == "manifest"
+        else:
+            assert extracted_payload.get("format") == metadata_format
 
         # Compare relevant fields based on format
         if metadata_format == "basic":
             assert extracted_payload.get("model_id") == original_payload.get("model_id")
             assert "timestamp" in extracted_payload
             assert extracted_payload.get("custom_metadata") == original_payload.get("custom_metadata")
-        elif metadata_format == "manifest":
+        elif metadata_format in ("manifest", "jumbf"):
             # Access nested manifest fields
             manifest_payload = extracted_payload.get("manifest", {})
             assert manifest_payload.get("claim_generator") == original_payload.get("claim_generator")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,8 +1,8 @@
 """
 Pytest configuration for integration tests.
 """
+
 import os
-import pytest
 
 
 def pytest_ignore_collect(collection_path, config):
@@ -13,5 +13,5 @@ def pytest_ignore_collect(collection_path, config):
     # Skip Gemini integration tests if API key is not set
     if collection_path.name == "test_gemini_integration.py" and not os.getenv("GEMINI_API_KEY"):
         return True
-    
+
     return False


### PR DESCRIPTION
## Summary
- implement a tiny JUMBF box serializer/deserializer
- mention new format in README and technical guide
- document JUMBF support in the changelog
- bump `__version__` to 2.4.2

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c956aee04832cbf13dea1a3fa55ba