### PR TITLE
Remove version from C2PA format references

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Key alignments include:
 - **CBOR Manifests**: Support for embedding full C2PA-compliant manifests using CBOR for a compact, standards-aligned format
 - **Hard binding approach**: Direct embedding of manifests into the content itself
 - **Shared mission** of improving content transparency and trust
+- **Spec version**: Currently aligned with the C2PA 2.2 specification
 
 Our implementation uses Unicode variation selectors (U+FE00 to U+FE0F) to invisibly embed C2PA manifests directly into text content, enabling provenance tracking and tamper detection without altering the visible appearance of the text.
 

--- a/docs/package/api-reference/unicode_metadata.md
+++ b/docs/package/api-reference/unicode_metadata.md
@@ -64,7 +64,7 @@ def embed_metadata(
     text: str,
     private_key: PrivateKeyTypes,
     signer_id: str,
-    metadata_format: Literal["basic", "manifest", "cbor_manifest", "c2pa_v2_2"] = "basic",
+    metadata_format: Literal["basic", "manifest", "cbor_manifest", "c2pa"] = "basic",
     c2pa_manifest: Optional[Dict[str, Any]] = None,
     model_id: Optional[str] = None,
     timestamp: Optional[Union[str, datetime, date, int, float]] = None,
@@ -88,8 +88,8 @@ Embeds metadata into text using Unicode variation selectors, signing with a priv
   - `basic`: A simple key-value payload.
   - `manifest`: A legacy C2PA-like manifest.
   - `cbor_manifest`: A CBOR-encoded version of the legacy manifest.
-  - `c2pa_v2_2`: The latest C2PA-compliant format using COSE Sign1.
-- `c2pa_manifest`: A dictionary representing the full C2PA v2.2 manifest. Required when `metadata_format` is `c2pa_v2_2`.
+  - `c2pa`: The C2PA-compliant format using COSE Sign1.
+- `c2pa_manifest`: A dictionary representing the full C2PA manifest. Required when `metadata_format` is `c2pa`.
 - `model_id`: Model identifier (used in 'basic' payload).
 - `timestamp`: Timestamp (datetime, ISO string, int/float epoch).
 - `target`: Where to embed metadata ('whitespace', 'punctuation', etc.).
@@ -237,7 +237,7 @@ embedded_text = UnicodeMetadata.embed_metadata(
     text=clean_text,
     private_key=private_key,
     signer_id=signer_id,
-    metadata_format='c2pa_v2_2',
+    metadata_format='c2pa',
     c2pa_manifest=c2pa_manifest,
 )
 

--- a/docs/package/changelog.md
+++ b/docs/package/changelog.md
@@ -1,6 +1,13 @@
 # Changelog
 
 This document provides a chronological list of notable changes for each version of EncypherAI.
+
+## 2.7.0 (07-08-2025)
+
+### Modified
+- Changed the public API so that the metadata format uses the generic value "c2pa" instead of the older "c2pa_v2_2". The version of C2PA alignment is now tracked in the README.md.
+- `metadata_format` now expects: `metadata_format: Literal["basic", "manifest", "cbor_manifest", "c2pa"] = "manifest"`
+
 ## 2.6.0 (07-07-2025)
 
 ### Added

--- a/docs/package/user-guide/c2pa-relationship.md
+++ b/docs/package/user-guide/c2pa-relationship.md
@@ -68,7 +68,7 @@ def run_c2pa_text_demo():
     }
 
     # 4. Embed the manifest into the text
-    # The `c2pa_v2_2` format handles all COSE signing and CBOR encoding internally.
+    # The `c2pa` format handles all COSE signing and CBOR encoding internally.
     embedded_text = UnicodeMetadata.embed_metadata(
         text=original_text,
         private_key=private_key,

--- a/docs/package/user-guide/extraction-verification.md
+++ b/docs/package/user-guide/extraction-verification.md
@@ -7,7 +7,7 @@ Verifying embedded metadata is a critical step to ensure the authenticity and in
 The primary method for verification is `UnicodeMetadata.verify_metadata()`. This method performs a series of checks to validate the embedded data:
 
 1.  **Extraction**: It first extracts the raw byte sequence from the Unicode variation selectors in the text.
-2.  **Format Detection**: It automatically detects the payload format (legacy `basic`/`manifest` or `c2pa_v2_2`).
+2.  **Format Detection**: It automatically detects the payload format (legacy `basic`/`manifest` or `c2pa`).
 3.  **Signature Validation**: It verifies the cryptographic signature using the key provided by the `public_key_provider`.
 4.  **Deep Manifest Validation (for C2PA v2.2)**: If a C2PA v2.2 manifest is detected, it performs additional, deeper validation:
     *   **COSE Signature**: Verifies the COSE_Sign1 structure.

--- a/encypher/core/payloads.py
+++ b/encypher/core/payloads.py
@@ -100,7 +100,7 @@ class OuterPayload(TypedDict):
     """
 
     # The format literal is extended to include new formats.
-    format: Literal["basic", "manifest", "cbor_manifest", "c2pa_v2_2", "jumbf"]
+    format: Literal["basic", "manifest", "cbor_manifest", "c2pa", "jumbf"]
     signer_id: str
     # The payload can be a dictionary for JSON-based formats, or a
     # base64-encoded string for binary formats like CBOR.

--- a/encypher/streaming/handlers.py
+++ b/encypher/streaming/handlers.py
@@ -35,7 +35,7 @@ class StreamingHandler:
         encode_first_chunk_only: bool = True,
         private_key: Optional[PrivateKeyTypes] = None,
         signer_id: Optional[str] = None,
-        metadata_format: Literal["basic", "manifest", "c2pa_v2_2"] = "c2pa_v2_2",
+        metadata_format: Literal["basic", "manifest", "c2pa"] = "c2pa",
         omit_keys: Optional[List[str]] = None,
         # For backward compatibility
         metadata: Optional[Dict[str, Any]] = None,
@@ -54,7 +54,7 @@ class StreamingHandler:
             metadata: (Deprecated) Alternative way to provide custom metadata. Use custom_metadata instead.
             signer_id: An identifier for the signer (associated with the public key).
             metadata_format: The structure of the metadata payload.
-                             'c2pa_v2_2' is the latest C2PA-compliant format.
+                             'c2pa' is the C2PA-compliant format.
             omit_keys: Optional list of metadata keys to omit from the payload prior to signing.
 
         Raises:
@@ -65,8 +65,8 @@ class StreamingHandler:
         logger.debug(f"Initializing StreamingHandler with target='{target}', encode_first_chunk_only={encode_first_chunk_only}")
 
         # --- Input Validation ---
-        if metadata_format not in ("basic", "manifest", "c2pa_v2_2"):
-            raise ValueError("metadata_format must be 'basic', 'manifest', or 'c2pa_v2_2'.")
+        if metadata_format not in ("basic", "manifest", "c2pa"):
+            raise ValueError("metadata_format must be 'basic', 'manifest', or 'c2pa'.")
 
         # Handle backward compatibility with 'metadata' parameter
         if metadata is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "encypher-ai"
-version = "2.6.0"
+version = "2.7.0"
 description = "Embed invisible metadata in AI-generated text using zero-width characters."
 readme = "README.md"
 authors = [{name = "EncypherAI Team"}]

--- a/tests/integration/test_c2pa.py
+++ b/tests/integration/test_c2pa.py
@@ -1,7 +1,7 @@
 """
-Integration tests for C2PA v2.2 compliance.
+Integration tests for C2PA compliance.
 
-This module tests the end-to-end functionality of C2PA v2.2 compliant
+This module tests the end-to-end functionality of C2PA compliant
 embedding, extraction, and verification.
 """
 
@@ -20,8 +20,8 @@ from encypher.core.unicode_metadata import UnicodeMetadata
 from encypher.interop.c2pa import encypher_manifest_to_c2pa_like_dict
 
 
-class TestC2PAv2_2Integration(unittest.TestCase):
-    """Test cases for C2PA v2.2 compliance integration."""
+class TestC2PAIntegration(unittest.TestCase):
+    """Test cases for C2PA compliance integration."""
 
     def setUp(self):
         """Set up test fixtures."""
@@ -31,7 +31,7 @@ class TestC2PAv2_2Integration(unittest.TestCase):
         self.signer_id = "test-signer-id"
 
         # Sample text content
-        self.test_text = "This is a test text for C2PA v2.2 compliance testing."
+        self.test_text = "This is a test text for C2PA compliance testing."
 
         # Sample timestamp for consistent testing
         self.timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -62,14 +62,14 @@ class TestC2PAv2_2Integration(unittest.TestCase):
         """Clean up test fixtures."""
         self.temp_dir.cleanup()
 
-    def test_c2pa_v2_2_embedding_and_extraction(self):
-        """Test embedding and extracting C2PA v2.2 compliant metadata."""
-        # Embed metadata with C2PA v2.2 format
+    def test_c2pa_embedding_and_extraction(self):
+        """Test embedding and extracting C2PA compliant metadata."""
+        # Embed metadata with C2PA format
         embedded_text = UnicodeMetadata.embed_metadata(
             text=self.test_text,
             private_key=self.private_key,
             signer_id=self.signer_id,
-            metadata_format="c2pa_v2_2",
+            metadata_format="c2pa",
             timestamp=self.timestamp,
             actions=self.actions,
             claim_generator="EncypherAI/2.4.0",
@@ -97,14 +97,14 @@ class TestC2PAv2_2Integration(unittest.TestCase):
         self.assertIn("c2pa.hash.data.v1", assertion_labels)
         self.assertIn("c2pa.soft_binding.v1", assertion_labels)
 
-    def test_c2pa_v2_2_verification(self):
-        """Test verification of C2PA v2.2 compliant metadata."""
-        # Embed metadata with C2PA v2.2 format
+    def test_c2pa_verification(self):
+        """Test verification of C2PA compliant metadata."""
+        # Embed metadata with C2PA format
         embedded_text = UnicodeMetadata.embed_metadata(
             text=self.test_text,
             private_key=self.private_key,
             signer_id=self.signer_id,
-            metadata_format="c2pa_v2_2",
+            metadata_format="c2pa",
             timestamp=self.timestamp,
             actions=self.actions,
             claim_generator="EncypherAI/2.4.0",
@@ -133,14 +133,14 @@ class TestC2PAv2_2Integration(unittest.TestCase):
         is_verified, _, _ = UnicodeMetadata.verify_metadata(embedded_text, wrong_key_resolver)
         self.assertFalse(is_verified)
 
-    def test_c2pa_v2_2_tamper_detection(self):
-        """Test tamper detection for C2PA v2.2 compliant metadata."""
-        # Embed metadata with C2PA v2.2 format
+    def test_c2pa_tamper_detection(self):
+        """Test tamper detection for C2PA compliant metadata."""
+        # Embed metadata with C2PA format
         embedded_text = UnicodeMetadata.embed_metadata(
             text=self.test_text,
             private_key=self.private_key,
             signer_id=self.signer_id,
-            metadata_format="c2pa_v2_2",
+            metadata_format="c2pa",
             timestamp=self.timestamp,
             actions=self.actions,
             claim_generator="EncypherAI/2.4.0",
@@ -162,7 +162,7 @@ class TestC2PAv2_2Integration(unittest.TestCase):
         self.assertFalse(is_verified)
 
     def test_c2pa_soft_binding(self):
-        """Test soft binding functionality for C2PA v2.2."""
+        """Test soft binding functionality for C2PA."""
         # Create a manifest with embedded data for soft binding
         embedded_data = "Unicode variation selector soft binding test data"
 

--- a/tests/integration/test_gemini_integration.py
+++ b/tests/integration/test_gemini_integration.py
@@ -46,7 +46,7 @@ def test_gemini_non_streaming():
         text=original_text,
         private_key=private_key,
         signer_id=signer_id,
-        metadata_format="c2pa_v2_2",
+        metadata_format="c2pa",
         custom_claims=custom_metadata,
         timestamp=int(time.time()),
     )
@@ -74,7 +74,7 @@ def test_gemini_streaming():
     streaming_handler = StreamingHandler(
         private_key=private_key,
         signer_id=signer_id,
-        metadata_format="c2pa_v2_2",
+        metadata_format="c2pa",
         custom_metadata={"gemini_model": "gemini-1.5-flash", "streaming": "true"},
         timestamp=int(time.time()),
     )


### PR DESCRIPTION
## Summary
- update README to note spec version
- rename `c2pa_v2_2` format to `c2pa`
- adjust streaming handler defaults
- update integration tests and docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_686ca54be18c832cb7eb3c211b1cdaca